### PR TITLE
fix: Fix minitest deprecated message

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,9 @@ name: Tests
 
 on:
   push:
+    branches: main
   pull_request:
-    branches: [ main ]
+    branches: main
 
 jobs:
   test:
@@ -14,8 +15,7 @@ jobs:
           - '2.7'
           - '3.0'
           - '3.1'
-          # FIXME: fix test suite for Ruby 3.2
-          # - '3.2'
+          - '3.2'
     steps:
       - uses: actions/checkout@v1
       - name: Set up Ruby

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rake", "< 11"
+gem "rake"
 gem "minitest"
 
 if ENV["rdoc"] == "master"

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ gemspec
 
 gem "rake", "< 11"
 gem "minitest"
-gem "hoe"
 
 if ENV["rdoc"] == "master"
   gem "rdoc", :github => "ruby/rdoc"

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -19,14 +19,14 @@ describe SDoc::Helpers do
       ]
 
       strings.each do |(html, stripped)|
-        @helpers.strip_tags(html).must_equal stripped
+        _(@helpers.strip_tags(html)).must_equal stripped
       end
     end
   end
 
   describe "#truncate" do
     it "should truncate the given text around a given length" do
-      @helpers.truncate("Hello world", length: 5).must_equal "Hello."
+      _(@helpers.truncate("Hello world", length: 5)).must_equal "Hello."
     end
   end
 end

--- a/spec/rdoc_generator_spec.rb
+++ b/spec/rdoc_generator_spec.rb
@@ -8,12 +8,12 @@ describe RDoc::Generator::SDoc do
   end
 
   it "should find sdoc generator" do
-    RDoc::RDoc::GENERATORS.must_include 'sdoc'
+    _(RDoc::RDoc::GENERATORS).must_include 'sdoc'
   end
 
   it "should use sdoc generator" do
-    @options.generator.must_equal RDoc::Generator::SDoc
-    @options.generator_name.must_equal 'sdoc'
+    _(@options.generator).must_equal RDoc::Generator::SDoc
+    _(@options.generator_name).must_equal 'sdoc'
   end
 
   it "should parse github option" do
@@ -23,8 +23,8 @@ describe RDoc::Generator::SDoc do
       @parser.parse %w[--github]
     end
 
-    err.wont_match(/^invalid options/)
-    @options.github.must_equal true
+    _(err).wont_match(/^invalid options/)
+    _(@options.github).must_equal true
   end
 
   it "should parse github short-hand option" do
@@ -34,15 +34,15 @@ describe RDoc::Generator::SDoc do
       @parser.parse %w[-g]
     end
 
-    err.wont_match(/^invalid options/)
-    @options.github.must_equal true
+    _(err).wont_match(/^invalid options/)
+    _(@options.github).must_equal true
   end
 
   it "should display SDoc version on -v or --version" do
     out_full  = `./bin/sdoc --version`
     out_short = `./bin/sdoc -v`
 
-    out_short.strip.must_equal SDoc::VERSION
-    out_full.strip.must_equal SDoc::VERSION
+    _(out_short.strip).must_equal SDoc::VERSION
+    _(out_full.strip).must_equal SDoc::VERSION
   end
 end


### PR DESCRIPTION
```
DEPRECATED: global use of must_equal from .... Use _(obj).must_equal instead. This will fail in Minitest 6.
```