### PR TITLE
fix: Fix outputting empty source_code

### DIFF
--- a/lib/sdoc/helpers.rb
+++ b/lib/sdoc/helpers.rb
@@ -25,12 +25,12 @@ module SDoc::Helpers
   end
 
   def method_source_code_and_url(rdoc_method)
-    source_code = rdoc_method.tokens_to_s if rdoc_method.token_stream
+    source_code = h(rdoc_method.tokens_to_s) if rdoc_method.token_stream
 
     if source_code&.match(/File\s(\S+), line (\d+)/)
       source_url = github_url(Regexp.last_match(1), line: Regexp.last_match(2))
     end
 
-    [rdoc_method.instance_of?(RDoc::GhostMethod) ? nil : h(source_code), source_url]
+    [rdoc_method.instance_of?(RDoc::GhostMethod) ? nil : source_code, source_url]
   end
 end


### PR DESCRIPTION
After merging #6, empty source_code is shown in generated HTML.

This PR fixes the issue.