### PR TITLE
fix: Create navigation before copy resources / refactor: Add `render_file` /  ci: Add Ruby 3.3 and ruby-head

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,8 @@ jobs:
           - '3.0'
           - '3.1'
           - '3.2'
+          - '3.3'
+          - ruby-head
     steps:
       - uses: actions/checkout@v1
       - name: Set up Ruby

--- a/lib/rdoc/generator/template/rails/class.rhtml
+++ b/lib/rdoc/generator/template/rails/class.rhtml
@@ -1,5 +1,5 @@
 ---
-title: <%= klass.full_name %>
+title: <%= context.full_name %>
 layout: default
 ---
 <div class="main">
@@ -7,26 +7,26 @@ layout: default
         <% if ENV['HORO_PROJECT_NAME'] %>
             <span><%= h ENV['HORO_PROJECT_NAME'] %> <%= h ENV['HORO_PROJECT_VERSION'] %></span><br />
         <% end %>
-        <div class="type"><%= klass.module? ? 'Module' : 'Class' %></div>
+        <div class="type"><%= context.module? ? 'Module' : 'Class' %></div>
         <h1>
-            <%= h klass.full_name %>
-            <% if klass.type == 'class' %>
+            <%= h context.full_name %>
+            <% if context.type == 'class' %>
                 <span class="parent">&lt;
-                    <% if String === klass.superclass %>
-                    <%= klass.superclass %>
-                    <% elsif !klass.superclass.nil? %>
-                    <a href="<%= klass.aref_to klass.superclass.path %>"><%= h klass.superclass.full_name %></a>
+                    <% if String === context.superclass %>
+                    <%= context.superclass %>
+                    <% elsif !context.superclass.nil? %>
+                    <a href="<%= context.aref_to context.superclass.path %>"><%= h context.superclass.full_name %></a>
                     <% end %>
                 </span>
             <% end %>
         </h1>
         <ul class="files">
-            <% klass.in_files.each do |file| %>
+            <% context.in_files.each do |file| %>
             <li><a href="<%= "#{rel_prefix}/#{h file.path}" %>"><%= h file.absolute_name %></a></li>
             <% end  %>
         </ul>
     </div>
     <div id="bodyContent">
-        <%= include_template '_context.rhtml', {:context => klass, :rel_prefix => rel_prefix} %>
+        <%= include_template '_context.rhtml', { context: context, rel_prefix: rel_prefix } %>
     </div>
 </div>

--- a/lib/rdoc/generator/template/rails/file.rhtml
+++ b/lib/rdoc/generator/template/rails/file.rhtml
@@ -1,5 +1,5 @@
 ---
-title: <%= file.name %>
+title: <%= context.name %>
 layout: default
 ---
 <div>
@@ -8,12 +8,12 @@ layout: default
             <span><%= h ENV['HORO_PROJECT_NAME'] %> <%= h ENV['HORO_PROJECT_VERSION'] %></span><br />
         <% end %>
         <h1>
-            <%= h file.name %>
+            <%= h context.name %>
         </h1>
         <ul class="files">
-            <% github = github_url(file.relative_name) if options.github %>
+            <% github = github_url(context.relative_name) if options.github %>
             <li>
-                <%= h file.relative_name %>
+                <%= h context.relative_name %>
                 <% if github %>
                     <a href="<%= github %>" target="_blank" class="github_url">on GitHub</a>
                 <% end %>
@@ -22,6 +22,6 @@ layout: default
     </div>
 
     <div id="bodyContent">
-        <%= include_template '_context.rhtml', {:context => file, :rel_prefix => rel_prefix} %>
+        <%= include_template '_context.rhtml', { context: context, rel_prefix: rel_prefix} %>
     </div>
 </div>

--- a/lib/sdoc/generator.rb
+++ b/lib/sdoc/generator.rb
@@ -89,9 +89,9 @@ class RDoc::Generator::SDoc
     @json_index.generate_gzipped
 
     FileUtils.mkdir_p(@output_dir)
+    generate_navigation # original code
     copy_resources
     generate_search_index
-    generate_navigation # original code
     generate_file_files
     generate_class_files
   end

--- a/lib/sdoc/generator.rb
+++ b/lib/sdoc/generator.rb
@@ -32,7 +32,6 @@ class RDoc::Generator::SDoc
 
   GENERATOR_DIRS = [File.join('sdoc', 'generator')]
 
-  TREE_FILE = File.join 'panel', 'tree.js'
   SEARCH_INDEX_FILE = File.join 'js', 'search_index.js'
 
   FILE_DIR = 'files'
@@ -94,7 +93,6 @@ class RDoc::Generator::SDoc
     @json_index.generate
     @json_index.generate_gzipped
     generate_search_index
-    generate_class_tree
 
     generate_navigation
 
@@ -157,17 +155,6 @@ class RDoc::Generator::SDoc
     self.render_template( templatefile, binding(), outfile ) unless @options.dry_run
   end
 
-  ### Create class tree structure and write it as json
-  def generate_class_tree
-    debug_msg "Generating class tree"
-    topclasses = @classes.select {|klass| !(RDoc::ClassModule === klass.parent) }
-    tree = generate_file_tree + generate_class_tree_level(topclasses)
-    debug_msg "  writing class tree to %s" % TREE_FILE
-    File.open(TREE_FILE, "w", 0644) do |f|
-      f.write('var tree = '); f.write(tree.to_json(:max_nesting => 0))
-    end unless @options.dry_run
-  end
-
   def generate_navigation
     topclasses = @classes.select { |klass| !(RDoc::ClassModule === klass.parent) }
     tree = generate_file_tree + generate_class_tree_level(topclasses)
@@ -179,7 +166,7 @@ class RDoc::Generator::SDoc
     include_template(templatefile, { tree: menu_tree, nested: false })
   end
 
-  ### Recursivly build class tree structure
+  # Recursivly build class tree structure
   def generate_class_tree_level(classes, visited = {})
     tree = []
     classes.select do |klass|


### PR DESCRIPTION
This pull request refactors the SDoc generator and updates its templates to improve consistency and reliability. The main changes include standardizing the use of the `context` variable in ERB templates, refactoring the generator to simplify file handling and output directory management, and updating the test workflow to support newer Ruby versions. These updates enhance maintainability and future compatibility.

**Template consistency improvements:**
* Updated all ERB templates in `lib/rdoc/generator/template/rails/` to use `context` instead of `klass` or `file`, ensuring a consistent interface for rendering documentation pages. [[1]](diffhunk://#diff-851237f6ef434d80c63b2cd4fe44a837b04a29d28172d8bc70132890c0366a9bL2-R30) [[2]](diffhunk://#diff-b3c1f70f8faaebbf0c1ff1dfe6f938c02615ccedd92c53148cf9eca68887fe7cL2-R2) [[3]](diffhunk://#diff-b3c1f70f8faaebbf0c1ff1dfe6f938c02615ccedd92c53148cf9eca68887fe7cL11-R16) [[4]](diffhunk://#diff-b3c1f70f8faaebbf0c1ff1dfe6f938c02615ccedd92c53148cf9eca68887fe7cL25-R25)

**SDoc generator refactoring:**
* Refactored `lib/sdoc/generator.rb` to standardize output directory handling using `@output_dir`, simplify initialization, and reduce redundant code. The generator now uses a helper method `render_file` for rendering documentation files. [[1]](diffhunk://#diff-5b261d37540c87fc1000a36ea9c5c5ba20744b31b5ff8c2d5affc53e78e35fdeL81-R94) [[2]](diffhunk://#diff-5b261d37540c87fc1000a36ea9c5c5ba20744b31b5ff8c2d5affc53e78e35fdeL121-L170) [[3]](diffhunk://#diff-5b261d37540c87fc1000a36ea9c5c5ba20744b31b5ff8c2d5affc53e78e35fdeL225-R197)
* Removed the unused `TREE_FILE` constant and the obsolete `generate_class_tree` method, streamlining the codebase and focusing tree generation logic within navigation. [[1]](diffhunk://#diff-5b261d37540c87fc1000a36ea9c5c5ba20744b31b5ff8c2d5affc53e78e35fdeL35) [[2]](diffhunk://#diff-5b261d37540c87fc1000a36ea9c5c5ba20744b31b5ff8c2d5affc53e78e35fdeL121-L170)

**Test workflow updates:**
* Added Ruby 3.3 and `ruby-head` to the GitHub Actions test matrix in `.github/workflows/test.yml`, ensuring CI coverage for the latest Ruby versions.