### PR TITLE
deps: Use rdoc `< 6.13`

### DIFF
--- a/lib/sdoc/version.rb
+++ b/lib/sdoc/version.rb
@@ -1,3 +1,3 @@
 module SDoc
-  VERSION = '1.0.0'
+  VERSION = '1.0.0-20250926'
 end

--- a/sdoc.gemspec
+++ b/sdoc.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.rdoc_options = ["--charset=UTF-8"]
   s.extra_rdoc_files = ["README.md"]
 
-  s.add_runtime_dependency "rdoc", ">= 5.0"
+  s.add_runtime_dependency "rdoc", "< 6.13"
   s.add_runtime_dependency "nokogiri"
   s.add_runtime_dependency "rouge"
   s.add_runtime_dependency "activesupport"


### PR DESCRIPTION
## rdoc v6.13

> Remove unused class_dir and file_dir attributes from generators

https://github.com/ruby/rdoc/releases/tag/v6.13.0

## Others

- Add date to versioning

## Reference

https://github.com/rails/sdoc/blob/ee479f9c1ba3d3f390b6c3e8ae2322c97c66b7b3/lib/sdoc/generator.rb#L109-L112