### PR TITLE
feat: Add `normalize_indentation` method

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gemspec
 gem "rake"
 gem "minitest"
 gem "minitest-reporters"
+gem "minitest-line"
 
 if ENV["rdoc"] == "master"
   gem "rdoc", :github => "ruby/rdoc"

--- a/lib/sdoc/helpers.rb
+++ b/lib/sdoc/helpers.rb
@@ -16,7 +16,7 @@ module SDoc::Helpers
       source_code = normalize_indentation(source_code)
     end
 
-    [rdoc_method.instance_of?(RDoc::GhostMethod) ? nil : source_code, source_url]
+    [(source_code unless rdoc_method.instance_of?(RDoc::GhostMethod)), source_url]
   end
 
   private

--- a/lib/sdoc/helpers.rb
+++ b/lib/sdoc/helpers.rb
@@ -13,8 +13,21 @@ module SDoc::Helpers
 
     if source_code&.match(/File\s(\S+), line (\d+)/)
       source_url = github_url(Regexp.last_match(1), line: Regexp.last_match(2))
+      source_code = normalize_indentation(source_code)
     end
 
     [rdoc_method.instance_of?(RDoc::GhostMethod) ? nil : source_code, source_url]
+  end
+
+  private
+
+  def normalize_indentation(source_code)
+    return source_code unless source_code.start_with?('# File')
+
+    source_lines = source_code.lines
+    return source_code if source_lines.size < 2
+
+    indent = source_lines.second[/\A */].size
+    source_code.gsub(/^ {#{indent}}/, '')
   end
 end

--- a/lib/sdoc/helpers.rb
+++ b/lib/sdoc/helpers.rb
@@ -28,6 +28,6 @@ module SDoc::Helpers
     return source_code if source_lines.size < 2
 
     indent = source_lines.second[/\A */].size
-    source_code.gsub(/^ {#{indent}}/, '')
+    source_code.gsub(/^ {1,#{indent}}/, '')
   end
 end

--- a/lib/sdoc/helpers.rb
+++ b/lib/sdoc/helpers.rb
@@ -8,28 +8,6 @@ module SDoc::Helpers
   require_relative "helpers/git"
   include ::SDoc::Helpers::Git
 
-  # Strips out HTML tags from a given string.
-  #
-  # Example:
-  #
-  #   strip_tags("<strong>Hello world</strong>") => "Hello world"
-  def strip_tags(text)
-    text.gsub(%r{</?[^>]+?>}, "")
-  end
-
-  # Truncates a given string. It tries to take whole sentences to have
-  # a meaningful description for SEO tags.
-  #
-  # The only available option is +:length+ which defaults to 200.
-  def truncate(text, options = {})
-    if text
-      length = options.fetch(:length, 200)
-      stop   = text.rindex(".", length - 1) || length
-
-      "#{text[0, stop]}."
-    end
-  end
-
   def method_source_code_and_url(rdoc_method)
     source_code = h(rdoc_method.tokens_to_s) if rdoc_method.token_stream
 

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -83,21 +83,43 @@ describe SDoc::Helpers do
 
       method = rdoc_top_level_for(<<~'RUBY').find_module_named("Foo").find_method("hi", false)
         module Foo
-          def hi(msg)
-            puts "Hi, #{msg}!"
-          end
+          def hi(msg) = puts "Hi, #{msg}!"
         end
       RUBY
 
       source_code, source_url = @helpers.method_source_code_and_url(method)
 
       expected_source = <<~EXPECTED.chomp
-        def hi(msg)
-          puts &quot;Hi, \#{msg}!&quot;
-        end
+        def hi(msg) = puts &quot;Hi, \#{msg}!&quot;
       EXPECTED
       _(source_code).must_include expected_source
       _(source_url).must_be_nil
+    end
+
+    it "normalizes indentation in source code" do
+      method = rdoc_top_level_for(<<~RUBY).find_module_named("Foo::Bar").find_method("baz", false)
+        module Foo
+          module Bar
+            def baz
+              puts "hello"
+              if true
+                puts "world"
+              end
+            end
+          end
+        end
+      RUBY
+
+      source_code, _source_url = @helpers.method_source_code_and_url(method)
+      expected_source = <<~EXPECTED.chomp
+        def baz
+          puts &quot;hello&quot;
+          if true
+            puts &quot;world&quot;
+          end
+        end
+      EXPECTED
+      _(source_code).must_include expected_source
     end
   end
 end

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -13,29 +13,6 @@ describe SDoc::Helpers do
     @helpers.options = RDoc::Options.new
   end
 
-  describe "#strip_tags" do
-    it "should strip out HTML tags from the given string" do
-      strings = [
-        [ %(<strong>Hello world</strong>),                                      "Hello world"          ],
-        [ %(<a href="Streams.html">Streams</a> are great),                      "Streams are great"    ],
-        [ %(<a href="https://github.com?x=1&y=2#123">zzak/sdoc</a> Standalone), "zzak/sdoc Standalone" ],
-        [ %(<h1 id="module-AR::Cb-label-Foo+Bar">AR Cb</h1>),                   "AR Cb"                ],
-        [ %(<a href="../Base.html">Base</a>),                                   "Base"                 ],
-        [ %(Some<br>\ntext),                                                    "Some\ntext"           ]
-      ]
-
-      strings.each do |(html, stripped)|
-        _(@helpers.strip_tags(html)).must_equal stripped
-      end
-    end
-  end
-
-  describe "#truncate" do
-    it "should truncate the given text around a given length" do
-      _(@helpers.truncate("Hello world", length: 5)).must_equal "Hello."
-    end
-  end
-
   describe "#method_source_code_and_url" do
     before :each do
       @helpers.options.github = true

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -148,6 +148,25 @@ describe SDoc::Helpers do
         EXPECTED
         _(source_code).must_include expected_source
       end
+
+      it "normalizes the code 3" do
+        method = rdoc_top_level_for(<<~RUBY).find_module_named("Foo").find_method("bar", false)
+          module Foo
+              def bar
+                  puts "hello"
+                end
+          end
+        RUBY
+
+        source_code, _source_url = @helpers.method_source_code_and_url(method)
+        puts source_code
+        expected_source = <<~EXPECTED.chomp
+          def bar
+              puts &quot;hello&quot;
+            end
+        EXPECTED
+        _(source_code).must_include expected_source
+      end
     end
   end
 end

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -95,30 +95,59 @@ describe SDoc::Helpers do
       _(source_url).must_be_nil
     end
 
-    it "normalizes indentation in source code" do
-      method = rdoc_top_level_for(<<~RUBY).find_module_named("Foo::Bar").find_method("baz", false)
-        module Foo
-          module Bar
-              def baz
-                  puts "hello"
-                  if true
-                    puts "world"
-                  end
+    describe "normalizing indentation" do
+      it "normalizes the code" do
+        method = rdoc_top_level_for(<<~RUBY).find_module_named("Foo::Bar").find_method("baz", false)
+          module Foo
+            module Bar
+                def baz
+                    puts "hello"
+                    if true
+                      puts "world"
+                    end
+                end
+            end
+          end
+        RUBY
+
+        source_code, _source_url = @helpers.method_source_code_and_url(method)
+        expected_source = <<~EXPECTED.chomp
+          def baz
+              puts &quot;hello&quot;
+              if true
+                puts &quot;world&quot;
               end
           end
-        end
-      RUBY
+        EXPECTED
+        _(source_code).must_include expected_source
+      end
 
-      source_code, _source_url = @helpers.method_source_code_and_url(method)
-      expected_source = <<~EXPECTED.chomp
-        def baz
-            puts &quot;hello&quot;
-            if true
-              puts &quot;world&quot;
+      it "normalizes the code 2" do
+        method = rdoc_top_level_for(<<~RUBY).find_module_named("Foo::Bar").find_method("baz", false)
+          module Foo
+            module Bar
+                def baz
+                  puts "hello"
+                    if true
+                      puts "world"
+                  end
+              end
             end
-        end
-      EXPECTED
-      _(source_code).must_include expected_source
+          end
+        RUBY
+
+        source_code, _source_url = @helpers.method_source_code_and_url(method)
+        puts source_code
+        expected_source = <<~EXPECTED.chomp
+          def baz
+            puts &quot;hello&quot;
+              if true
+                puts &quot;world&quot;
+            end
+          end
+        EXPECTED
+        _(source_code).must_include expected_source
+      end
     end
   end
 end

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -137,7 +137,6 @@ describe SDoc::Helpers do
         RUBY
 
         source_code, _source_url = @helpers.method_source_code_and_url(method)
-        puts source_code
         expected_source = <<~EXPECTED.chomp
           def baz
             puts &quot;hello&quot;
@@ -159,7 +158,6 @@ describe SDoc::Helpers do
         RUBY
 
         source_code, _source_url = @helpers.method_source_code_and_url(method)
-        puts source_code
         expected_source = <<~EXPECTED.chomp
           def bar
               puts &quot;hello&quot;

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -77,5 +77,27 @@ describe SDoc::Helpers do
       _(source_code).must_match %r{# File .+\.rb, line 2\b}
       _(source_url).must_be_nil
     end
+
+    it "sanitizes source code" do
+      @helpers.options.github = false
+
+      method = rdoc_top_level_for(<<~'RUBY').find_module_named("Foo").find_method("hi", false)
+        module Foo
+          def hi(msg)
+            puts "Hi, #{msg}!"
+          end
+        end
+      RUBY
+
+      source_code, source_url = @helpers.method_source_code_and_url(method)
+
+      expected_source = <<~EXPECTED.chomp
+        def hi(msg)
+          puts &quot;Hi, \#{msg}!&quot;
+        end
+      EXPECTED
+      _(source_code).must_include expected_source
+      _(source_url).must_be_nil
+    end
   end
 end

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -88,7 +88,6 @@ describe SDoc::Helpers do
       RUBY
 
       source_code, source_url = @helpers.method_source_code_and_url(method)
-
       expected_source = <<~EXPECTED.chomp
         def hi(msg) = puts &quot;Hi, \#{msg}!&quot;
       EXPECTED
@@ -100,12 +99,12 @@ describe SDoc::Helpers do
       method = rdoc_top_level_for(<<~RUBY).find_module_named("Foo::Bar").find_method("baz", false)
         module Foo
           module Bar
-            def baz
-              puts "hello"
-              if true
-                puts "world"
+              def baz
+                  puts "hello"
+                  if true
+                    puts "world"
+                  end
               end
-            end
           end
         end
       RUBY
@@ -113,10 +112,10 @@ describe SDoc::Helpers do
       source_code, _source_url = @helpers.method_source_code_and_url(method)
       expected_source = <<~EXPECTED.chomp
         def baz
-          puts &quot;hello&quot;
-          if true
-            puts &quot;world&quot;
-          end
+            puts &quot;hello&quot;
+            if true
+              puts &quot;world&quot;
+            end
         end
       EXPECTED
       _(source_code).must_include expected_source


### PR DESCRIPTION
| Before | After |
|---|---|
| <img width="992" height="779" alt="image" src="https://github.com/user-attachments/assets/ece9d4bd-273d-427b-a1cc-b7b36f9f6590" /> | <img width="994" height="756" alt="image" src="https://github.com/user-attachments/assets/ec6c2ed0-71a2-47c8-83a2-c5840b0f94bd" /> | 

## Changes

- refactor: Remove `strip_tags` and `truncate` since they are not used
- feat: Add `normalize_indentation`
- deps: Add `minitest-line` to line-specific tests

## Testing

- [x] Build railsdoc 

---

This pull request focuses on cleaning up unused helper methods and improving the handling of source code formatting in the `SDoc::Helpers` module. It removes obsolete methods and their tests, and introduces a new method to normalize indentation for extracted source code, along with comprehensive tests for this functionality.

**Helper method cleanup:**

* Removed the `strip_tags` and `truncate` methods from `lib/sdoc/helpers.rb`, as well as their associated tests in `spec/helpers_spec.rb`. These methods were no longer needed. [[1]](diffhunk://#diff-dd4d93eafec97b91e2052097a2a1b91447aad0c52f4a002eb0aa2ddb48e2d68cL11-R31) [[2]](diffhunk://#diff-7180d0647da58946e9aaf6b811e78382d5dbc959302bd26ad4a5c6009799e211L16-L38)

**Source code formatting improvements:**

* Added a new private method `normalize_indentation` to `SDoc::Helpers`, which ensures that method source code extracted from documentation has normalized indentation. This helps produce cleaner and more consistent code snippets.
* Updated `method_source_code_and_url` to use `normalize_indentation` when extracting source code, improving code readability in generated documentation.
* Added several new tests in `spec/helpers_spec.rb` to verify that source code is correctly sanitized and indentation is normalized in various scenarios.

**Development tooling:**

* Added the `minitest-line` gem to the `Gemfile` to improve the testing workflow during development.