### PR TITLE
feat: Add `description_for`, `description_for`, `link_to`, `link_to_if`

### DIFF
--- a/lib/rdoc/generator/template/rails/_context.rhtml
+++ b/lib/rdoc/generator/template/rails/_context.rhtml
@@ -143,21 +143,18 @@
           <%= description_for method %>
 
           <% unless method.aliases.empty? %>
-            <div class="aka">
-              Also aliased as: <%= method.aliases.map do |aka|
-                if aka.parent then # HACK lib/rexml/encodings
-                  %{<a href="#{context.aref_to aka.path}">#{h aka.name}</a>}
-                else
-                  h aka.name
-                end
-              end.join ", " %>
-            </div>
+            <p class="method__aka">
+              Also aliased as:
+              <%# Sometimes a parent cannot be determined. See ruby/rdoc@85ebfe13dc. %>
+              <%= method.aliases.map { |aka| link_to_if aka.parent, short_name_for(aka), aka }.join(", ") %>.
+            </p>
           <% end %>
 
-          <% if method.is_alias_for then %>
-            <div class="aka">
-              Alias for: <a href="<%= context.aref_to method.is_alias_for.path %>"><%= h method.is_alias_for.name %></a>
-            </div>
+          <% if alias_for = method.is_alias_for then %>
+            <p class="method__aka">
+              Alias for:
+              <%= link_to short_name_for(alias_for), alias_for %>.
+            </p>
           <% end %>
 
           <% source_code, source_url = method_source_code_and_url(method) %>

--- a/lib/rdoc/generator/template/rails/_context.rhtml
+++ b/lib/rdoc/generator/template/rails/_context.rhtml
@@ -138,19 +138,9 @@
       <h2 id="<%= type.to_s + "-" + visibility.to_s %>-methods"><%= type.capitalize %> <%= visibility.to_s.capitalize %> methods</h2>
       <% methods.each do |method| %>
         <div class="method">
-          <h3 id="<%= method.aref %>">
-            <% if method.call_seq %>
-              <%= method.call_seq.gsub(/->/, '&rarr;').gsub(/\n(.)/, '<br />\1') %>
-            <% else %>
-              <%= h method.name %><%= h method.params %>
-            <% end %>
-          </h3>
+          <h3 id="<%= method.aref %>"><%= method_signature method %></h3>
 
-          <% if method.comment %>
-            <div class="description">
-              <%= method.description.strip %>
-            </div>
-          <% end %>
+          <%= description_for method %>
 
           <% unless method.aliases.empty? %>
             <div class="aka">

--- a/lib/sdoc/helpers.rb
+++ b/lib/sdoc/helpers.rb
@@ -8,6 +8,11 @@ module SDoc::Helpers
   require_relative "helpers/git"
   include ::SDoc::Helpers::Git
 
+  def short_name_for(named)
+    named = named.name if named.is_a?(RDoc::CodeObject)
+    "<code>#{h named}</code>"
+  end
+
   def description_for(rdoc_object)
     if rdoc_object.comment && !rdoc_object.comment.empty?
       %(<div class="description">#{rdoc_object.description}</div>)

--- a/lib/sdoc/helpers.rb
+++ b/lib/sdoc/helpers.rb
@@ -8,6 +8,25 @@ module SDoc::Helpers
   require_relative "helpers/git"
   include ::SDoc::Helpers::Git
 
+  def description_for(rdoc_object)
+    if rdoc_object.comment && !rdoc_object.comment.empty?
+      %(<div class="description">#{rdoc_object.description}</div>)
+    end
+  end
+
+  def method_signature(rdoc_method)
+    signature = if rdoc_method.call_seq
+      # Support specifying a call-seq like `to_s -> string`
+      rdoc_method.call_seq.gsub(/^\s*([^(\s]+)(.*?)(?: -> (.+))?$/) do
+        "<b>#{h $1}</b>#{h $2}#{" <span class=\"returns\">&rarr;</span> #{h $3}" if $3}"
+      end
+    else
+      "<b>#{h rdoc_method.name}</b>#{h rdoc_method.params}"
+    end
+
+    "<code>#{signature}</code>"
+  end
+
   def method_source_code_and_url(rdoc_method)
     source_code = h(rdoc_method.tokens_to_s) if rdoc_method.token_stream
 


### PR DESCRIPTION
This pull request introduces a new set of helper methods for generating HTML links and improves the rendering of method documentation in the Rails RDoc template. The main focus is on standardizing link generation, improving code readability, and enhancing the flexibility and testability of documentation helpers.

**Enhancements to documentation rendering:**

* Refactored method documentation rendering in `_context.rhtml` to use new helper methods: `method_signature`, `description_for`, `link_to`, `link_to_if`, and `short_name_for`, resulting in cleaner and more consistent HTML output for method signatures, descriptions, and aliases.

**New helper methods in `SDoc::Helpers`:**

* Added `link_to`, `link_to_if`, `short_name_for`, `full_name_for`, `description_for`, and `method_signature` methods to standardize and simplify the generation of HTML links and formatted documentation elements, including special handling for RDoc code objects and HTML attributes.

**Testing improvements:**

* Added comprehensive tests for the new helper methods in `spec/helpers_spec.rb`, covering various scenarios for link generation, attribute handling, code object support, and conditional linking.