### PR TITLE
feat: Add `link_to_external` for nested method content

### DIFF
--- a/lib/rdoc/generator/template/rails/_context.rhtml
+++ b/lib/rdoc/generator/template/rails/_context.rhtml
@@ -170,7 +170,7 @@
               <% end %>
             </details>
           <% elsif source_url %>
-            <a href="<%= source_url %>" target="_blank" class="github_url">🔎 See on GitHub</a>
+            <p class="method__source"><%= link_to_external "🔎 See on GitHub", source_url %></p>
           <% end %>
         </div>
         <% end %><%# methods.each %>

--- a/lib/sdoc/helpers.rb
+++ b/lib/sdoc/helpers.rb
@@ -34,6 +34,14 @@ module SDoc::Helpers
     condition ? link_to(text, *args) : _link_body(text)
   end
 
+  def link_to_external(text, url, html_attributes = {})
+    html_attributes = html_attributes.transform_keys(&:to_s)
+    html_attributes = { "target" => "_blank", "class" => nil }.merge(html_attributes)
+    html_attributes["class"] = [*html_attributes["class"], "external-link"].join(" ")
+
+    link_to(text, url, html_attributes)
+  end
+
   def short_name_for(named)
     named = named.name if named.is_a?(RDoc::CodeObject)
     "<code>#{h named}</code>"

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -110,6 +110,28 @@ describe SDoc::Helpers do
     end
   end
 
+  describe "#link_to_external" do
+    it "sets class='external-link' and target='_blank' by default" do
+      _(@helpers.link_to_external("foo", "bar")).
+        must_equal %(<a href="bar" target="_blank" class="external-link">foo</a>)
+    end
+
+    it "supports additional classes" do
+      _(@helpers.link_to_external("foo", "bar", class: "qux")).
+        must_equal %(<a href="bar" target="_blank" class="qux external-link">foo</a>)
+    end
+
+    it "supports overriding target" do
+      _(@helpers.link_to_external("foo", "bar", target: "_self")).
+        must_equal %(<a href="bar" target="_self" class="external-link">foo</a>)
+    end
+
+    it "supports additional attributes" do
+      _(@helpers.link_to_external("foo", "bar", "data-hoge": "fuga")).
+        must_equal %(<a href="bar" target="_blank" class="external-link" data-hoge="fuga">foo</a>)
+    end
+  end
+
   describe "#method_source_code_and_url" do
     before :each do
       @helpers.options.github = true


### PR DESCRIPTION
This pull request introduces a new `link_to_external` helper to standardize the creation of external links with consistent attributes, updates the Rails template to use this helper for GitHub source links, and adds comprehensive tests to ensure correct behavior.

**Helper function improvements:**

* Added a new `link_to_external` helper in `lib/sdoc/helpers.rb` to generate external links with `target="_blank"` and a default `external-link` CSS class, while allowing for additional attributes and class overrides.

**Template updates:**

* Updated the GitHub source link in `lib/rdoc/generator/template/rails/_context.rhtml` to use the new `link_to_external` helper, ensuring consistent markup and behavior for external links.

**Testing enhancements:**

* Added a test suite for `link_to_external` in `spec/helpers_spec.rb`, covering default attributes, additional classes, target overrides, and support for extra HTML attributes.