### PR TITLE
Add "Definition files"

### DIFF
--- a/lib/rdoc/generator/template/rails/_context.rhtml
+++ b/lib/rdoc/generator/template/rails/_context.rhtml
@@ -178,10 +178,12 @@
     <% end %><%# context.methods_by_type %>
   <% end %><%# context.each_section %>
 
-  <h2>Definition files</h2>
-  <ul class="files">
+  <% if context.in_files.any? %>
+    <h2>Definition files</h2>
+    <ul class="files">
       <% context.in_files.each do |file| %>
       <li><a href="<%= "#{rel_prefix}/#{h file.path}" %>"><%= h file.absolute_name %></a></li>
       <% end %>
-  </ul>
+    </ul>
+  <% end %>
 </div>

--- a/lib/rdoc/generator/template/rails/_context.rhtml
+++ b/lib/rdoc/generator/template/rails/_context.rhtml
@@ -177,4 +177,11 @@
       <% end %><%# visibilities.each %>
     <% end %><%# context.methods_by_type %>
   <% end %><%# context.each_section %>
+
+  <h2>Definition files</h2>
+  <ul class="files">
+      <% context.in_files.each do |file| %>
+      <li><a href="<%= "#{rel_prefix}/#{h file.path}" %>"><%= h file.absolute_name %></a></li>
+      <% end %>
+  </ul>
 </div>

--- a/lib/rdoc/generator/template/rails/class.rhtml
+++ b/lib/rdoc/generator/template/rails/class.rhtml
@@ -20,13 +20,14 @@ layout: default
                 </span>
             <% end %>
         </h1>
-        <ul class="files">
-            <% context.in_files.each do |file| %>
-            <li><a href="<%= "#{rel_prefix}/#{h file.path}" %>"><%= h file.absolute_name %></a></li>
-            <% end  %>
-        </ul>
     </div>
     <div id="bodyContent">
         <%= include_template '_context.rhtml', { context: context, rel_prefix: rel_prefix } %>
+        <h2>Definition files</h2>
+        <ul class="files">
+            <% context.in_files.each do |file| %>
+            <li><a href="<%= "#{rel_prefix}/#{h file.path}" %>"><%= h file.absolute_name %></a></li>
+            <% end %>
+        </ul>
     </div>
 </div>

--- a/lib/rdoc/generator/template/rails/class.rhtml
+++ b/lib/rdoc/generator/template/rails/class.rhtml
@@ -7,7 +7,7 @@ layout: default
         <% if ENV['HORO_PROJECT_NAME'] %>
             <span><%= h ENV['HORO_PROJECT_NAME'] %> <%= h ENV['HORO_PROJECT_VERSION'] %></span><br />
         <% end %>
-        <div class="type"><%= context.module? ? 'Module' : 'Class' %></div>
+        <div class="type"><%= context.type %></div>
         <h1>
             <%= h context.full_name %>
             <% if context.type == 'class' %>

--- a/lib/rdoc/generator/template/rails/class.rhtml
+++ b/lib/rdoc/generator/template/rails/class.rhtml
@@ -23,11 +23,5 @@ layout: default
     </div>
     <div id="bodyContent">
         <%= include_template '_context.rhtml', { context: context, rel_prefix: rel_prefix } %>
-        <h2>Definition files</h2>
-        <ul class="files">
-            <% context.in_files.each do |file| %>
-            <li><a href="<%= "#{rel_prefix}/#{h file.path}" %>"><%= h file.absolute_name %></a></li>
-            <% end %>
-        </ul>
     </div>
 </div>


### PR DESCRIPTION
This pull request updates the Rails RDoc template to improve how definition files are displayed and to make the class/module type label more accurate. The main changes are a refactor to move the list of definition files to a more appropriate location and to use a more flexible method for displaying the type of context.

Template improvements:

* Moved the display of definition files from `class.rhtml` to `_context.rhtml`, so the list of files now appears in the context section only when relevant (`context.in_files.any?`). [[1]](diffhunk://#diff-506ffe0ae5143c47419fa360c4cb435e744cdc30620f5011e5df1c2a3ca08ac0R180-R188) [[2]](diffhunk://#diff-851237f6ef434d80c63b2cd4fe44a837b04a29d28172d8bc70132890c0366a9bL23-L27)
* Changed the type label in `class.rhtml` to use `context.type` instead of a hardcoded check, allowing for more accurate and flexible type display.